### PR TITLE
email & boardController abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,4 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,git,java,maven,eclipse,intellij,gradle,netbeans,visualstudiocode
 
 application.yaml
+env.properties

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
+	// java mail sender
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/apptive/devlog/auth/controller/UserController.java
+++ b/src/main/java/apptive/devlog/auth/controller/UserController.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/apptive/devlog/auth/repository/UserRepository.java
+++ b/src/main/java/apptive/devlog/auth/repository/UserRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    Optional<User> findByName(String name);
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/apptive/devlog/auth/service/UserService.java
+++ b/src/main/java/apptive/devlog/auth/service/UserService.java
@@ -4,8 +4,13 @@ import apptive.devlog.auth.entity.User;
 import apptive.devlog.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class UserService {
 
@@ -39,5 +44,16 @@ public class UserService {
     // 닉네임 중복 체크
     public boolean isNicknameDuplicated(String nickname){
         return userRepository.existsByNickname(nickname);
+    }
+
+    public User getUser(String name){
+        Optional<User> user = userRepository.findByName(name);
+
+        if(user.isEmpty()){
+            throw new NoSuchElementException("해당 사용자는 존재하지 않습니다.");
+        }
+        else{
+            return user.get();
+        }
     }
 }

--- a/src/main/java/apptive/devlog/board/controller/BoardController.java
+++ b/src/main/java/apptive/devlog/board/controller/BoardController.java
@@ -1,17 +1,24 @@
 package apptive.devlog.board.controller;
 
+import apptive.devlog.auth.entity.User;
+import apptive.devlog.auth.service.UserService;
 import apptive.devlog.board.entity.Comment;
 import apptive.devlog.board.entity.Post;
 import apptive.devlog.board.service.CommentService;
 import apptive.devlog.board.service.PostService;
 import apptive.devlog.board.service.ReplyService;
+import apptive.devlog.mail.controller.MailController;
+import apptive.devlog.mail.service.MailService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/board")
@@ -20,10 +27,13 @@ public class BoardController {
     private final PostService postService;
     private final CommentService commentService;
     private final ReplyService replyService;
+    private final MailService mailService;
+    private final UserService userService;
 
     // 게시물 생성
     @PostMapping("/posts")
     public ResponseEntity<Post> createPost(@RequestBody Post post, HttpServletRequest request) {
+        // 게시물 생성
         Post createdPost = postService.create(post);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdPost); // 201
     }
@@ -59,25 +69,17 @@ public class BoardController {
     // 댓글 생성
     @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<Comment> createComment(@PathVariable Long postId, @RequestBody Comment comment){
-        // 게시물에 댓글 연결
-        comment.setPost(postService.get(postId));
-        Comment createdComment = commentService.create(comment);
+        // 게시물에 댓글 연결 후 댓글 알림
+        Comment createdComment = commentService.createAndNotify(postId, comment);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdComment); // 201
     }
 
     // 게시물 댓글 목록 조회
 
-    //getNotDeleted 를 써서 stream으로 뽑아내는 것과
-    // getNotDeletedForPost 등 애초에 Repository랑 Service계층에서 함수를 매우 많이 만들어서
-    // controller에서는 함수만 쓰는 방식
-    // 후자가 최적화에는 유리해 보이는데
-    // 이를 위해서 이름이 매우 긴 메소드를 일일이 명세해서 사용해야 하는가
+    // commentService.getValidCommentByPostId() 사용
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<List<Comment>> getCommentsForPost(@PathVariable Long postId) {
-        List<Comment> comments = commentService.getNotDeleted()
-                .stream()
-                .filter(comment -> comment.getPost().getId().equals(postId))
-                .toList();
+        List<Comment> comments = commentService.getValidCommentByPostId(postId);
         if(comments.isEmpty()) {
             return ResponseEntity.noContent().build(); // 404
         }

--- a/src/main/java/apptive/devlog/board/entity/Post.java
+++ b/src/main/java/apptive/devlog/board/entity/Post.java
@@ -28,6 +28,6 @@ public class Post {
     private Long likeCount;
     private Boolean isDeleted;
 
-    @OneToMany(mappedBy = "Post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Comment> commentList;
 }

--- a/src/main/java/apptive/devlog/board/repository/CommentRepository.java
+++ b/src/main/java/apptive/devlog/board/repository/CommentRepository.java
@@ -2,9 +2,14 @@ package apptive.devlog.board.repository;
 
 import apptive.devlog.board.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByIsDeletedFalse();
+
+    @Query("SELECT c From Comment c Where c.post.id = :postId AND c.isDeleted = false")
+    List<Comment> findValidByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/apptive/devlog/board/repository/PostDataRepository.java
+++ b/src/main/java/apptive/devlog/board/repository/PostDataRepository.java
@@ -1,10 +1,11 @@
 package apptive.devlog.board.repository;
 
+import apptive.devlog.auth.entity.User;
 import apptive.devlog.board.entity.PostData;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostDataRepository extends JpaRepository<PostData, Long> {
-    List<PostData> findByIsDeletedFalse();
 }

--- a/src/main/java/apptive/devlog/board/repository/PostRepository.java
+++ b/src/main/java/apptive/devlog/board/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package apptive.devlog.board.repository;
 
+import apptive.devlog.auth.entity.User;
 import apptive.devlog.board.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/apptive/devlog/board/service/PostDataService.java
+++ b/src/main/java/apptive/devlog/board/service/PostDataService.java
@@ -42,9 +42,4 @@ public class PostDataService {
     public List<PostData> getAll() {
         return postDataRepository.findAll();
     }
-
-    // 유효한 데이터 조회
-    public List<PostData> getNotDeleted() {
-        return postDataRepository.findByIsDeletedFalse();
-    }
 }

--- a/src/main/java/apptive/devlog/board/service/PostService.java
+++ b/src/main/java/apptive/devlog/board/service/PostService.java
@@ -1,5 +1,6 @@
 package apptive.devlog.board.service;
 
+import apptive.devlog.auth.entity.User;
 import apptive.devlog.auth.repository.UserRepository;
 import apptive.devlog.board.entity.Post;
 import apptive.devlog.board.entity.PostData;
@@ -17,7 +18,7 @@ import java.util.List;
 public class PostService {
     private final PostRepository postRepository;
 
-    // 생성
+    // 생성 후 이메일 전송
     public Post create(Post post){
         post.setCreatedAt(LocalDate.now());
         post.setUpdatedAt(LocalDate.now());
@@ -50,6 +51,13 @@ public class PostService {
     public Post get(Long id){
         return postRepository.findById(id).orElseThrow(
                 () -> new EntityNotFoundException("해당 게시글을 찾을 수 없습니다."));
+    }
+
+    public User getUserById(Long id){
+        Post post = postRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException("해당 게시글을 찾을 수 없습니다.")
+        );
+        return post.getUser();
     }
 
     //모든 게시글 조회

--- a/src/main/java/apptive/devlog/config/MailConfig.java
+++ b/src/main/java/apptive/devlog/config/MailConfig.java
@@ -1,0 +1,9 @@
+package apptive.devlog.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@PropertySource("classpath:env.properties")
+public class MailConfig {
+}

--- a/src/main/java/apptive/devlog/config/WebSecurityConfig.java
+++ b/src/main/java/apptive/devlog/config/WebSecurityConfig.java
@@ -32,6 +32,7 @@ public class WebSecurityConfig {
                         // 로그인/회원가입 페이지 인증 없이 접근 허용
                         .requestMatchers("/users/login", "/users/signup").permitAll()
                         .requestMatchers("/api/board").permitAll() // board api 테스트용
+                        .requestMatchers("/mail/html").permitAll() // mail api 테스트용
                         .requestMatchers("/h2-console/**").permitAll() // H2 콘솔용 설정
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/apptive/devlog/mail/controller/MailController.java
+++ b/src/main/java/apptive/devlog/mail/controller/MailController.java
@@ -1,0 +1,24 @@
+package apptive.devlog.mail.controller;
+
+import apptive.devlog.mail.service.MailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/mail")
+@RequiredArgsConstructor
+public class MailController {
+    private final MailService mailService;
+
+    @GetMapping("/simple")
+    public void sendSimpleMailMessage(String email) {
+        mailService.sendSimpleMailMessage(email);
+    }
+
+    @GetMapping("/html")
+    public void sendMimeMessage(String email) {
+        mailService.sendMimeMessage(email);
+    }
+}

--- a/src/main/java/apptive/devlog/mail/service/MailService.java
+++ b/src/main/java/apptive/devlog/mail/service/MailService.java
@@ -1,0 +1,75 @@
+package apptive.devlog.mail.service;
+
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@Slf4j
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+
+    public void sendSimpleMailMessage(String email) {
+        SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+
+        try{
+            simpleMailMessage.setTo(email);
+            simpleMailMessage.setSubject("메일 제목 : 작성 완료");
+            simpleMailMessage.setText("내용 : 글 작성 완료");
+
+            javaMailSender.send(simpleMailMessage);
+
+            log.info("메일 발송 성공!");
+        }
+        catch (Exception e){
+            log.info("메일 발송 실패!");
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void sendMimeMessage(String email) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        try{
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+
+            //수신자
+            mimeMessageHelper.setTo(email);
+
+            mimeMessageHelper.setSubject("댓글 알림 메시지입니다.");
+
+            String content = """
+                    <!DOCTYPE html>
+                        <html xmlns:th="http://www.thymeleaf.org">
+                            <body>
+                                <div style="margin:100px;">
+                                    <h1> 댓글 알림 </h1>
+                                    <br>
+                                        <div align="center" style="border:1px solid black;">
+                                            <h3> 작성하신 글에 댓글 또는 대댓글이 추가되었습니다. </h3>
+                                        </div>
+                                    <br/>
+                                </div>
+                            </body>
+                        </html>
+                    """;
+            mimeMessageHelper.setText(content, true);
+
+            javaMailSender.send(mimeMessage);
+
+            log.info("메일 발송 성공!");
+        }
+        catch (Exception e){
+            log.info("메일 발송 실패!");
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,14 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
+# java mail sender
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${mail.username}
+spring.mail.password=${mail.password}
+# ?? ? ?? ??
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.timeout=5000
+# SMTP ?? ?? ?? ??
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true

--- a/src/main/resources/env.properties
+++ b/src/main/resources/env.properties
@@ -1,0 +1,3 @@
+mail.username=sk124590@gmail.com
+mail.password=atdemcsjqkcnzewc
+#maxevrjivrhgqgcc


### PR DESCRIPTION
- email 알림 기능 추가
댓글이 추가되었을 때 Post 작성자에게 email 전송 구현

- CommentService 
자동으로 생성되는 이름 복잡한 JPA 메서드 대신 @Query 사용해서 직접 SQL작성

-boardController 추상화
기존 컨트롤러에 존재하던 로직과 email 알림 기능 로직을 CommetService에 구현해서 Controller 간결화